### PR TITLE
Add production switch for db connection

### DIFF
--- a/api/dbConfig/init.js
+++ b/api/dbConfig/init.js
@@ -1,12 +1,18 @@
 const { Pool } = require("pg");
 const connectionString = process.env.DATABASE_URL
 
-const pool = new Pool({
-    connectionString,
-    ssl: {
-      rejectUnauthorized: false
-    }
-})
+const env = process.env.NODE_ENV;
+
+let options;
+
+if (env === "production") {
+  options = { connectionString, ssl: { rejectUnauthorized: false } }
+} else {
+  options = { connectionString }
+}
+
+const pool = new Pool(options);
+
 module.exports = {
   async query(text, params) {
     const start = Date.now();


### PR DESCRIPTION
Checks NODE_ENV and enables ssl connections accordingly.

I think heroku should set `NODE_ENV=production` automatically but we should check by deploying this PR